### PR TITLE
Add customizable path separator to JSON methods

### DIFF
--- a/DecSm.Extensions.Json.Benchmarks/DecSm.Extensions.Json.Benchmarks.csproj
+++ b/DecSm.Extensions.Json.Benchmarks/DecSm.Extensions.Json.Benchmarks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
+    <NoWarn>$(NoWarn);1591;RCS1001;</NoWarn>
   </PropertyGroup>
 
   <!--  Packages-->

--- a/DecSm.Extensions.Json.Benchmarks/JsonUtilBenchmarks.cs
+++ b/DecSm.Extensions.Json.Benchmarks/JsonUtilBenchmarks.cs
@@ -94,7 +94,7 @@ public class JsonUtilBenchmarks
     }
 
     [Benchmark(Description = "Flatten: JsonNode -> pairs")]
-    public IReadOnlyDictionary<string, string?> Flatten_Benchmark() =>
+    public IDictionary<string, string?> Flatten_Benchmark() =>
         JsonExtensions.Flatten(_jsonNode);
 
     [Benchmark(Description = "Unflatten: pairs -> JsonObject")]

--- a/DecSm.Extensions.Json/JsonExtensions.Flatten.cs
+++ b/DecSm.Extensions.Json/JsonExtensions.Flatten.cs
@@ -17,7 +17,7 @@ public static partial class JsonExtensions
     /// </summary>
     /// <param name="node">The JSON node to flatten. Can be a JsonObject, JsonArray, or primitive value.</param>
     /// <returns>
-    ///     A read-only dictionary mapping each path to its string representation.
+    ///     A dictionary mapping each path to its string representation.
     ///     - Keys use colons for object properties and [index] notation for arrays.
     ///     - Values are the string representation of the JSON values (null for JSON null values).
     /// </returns>
@@ -29,17 +29,17 @@ public static partial class JsonExtensions
     /// // Result: [("user:name", "John"), ("user:tags:[0]", "admin"), ("user:tags:[1]", "user")]
     /// ]]></code>
     /// </example>
-    public static IReadOnlyDictionary<string, string?> Flatten(JsonNode node)
+    public static IDictionary<string, string?> Flatten(JsonNode node)
     {
         ArgumentNullException.ThrowIfNull(node);
 
-        var keyLookup = new Dictionary<string, int>();
-        var flattened = new List<KeyValuePair<string, string?>>();
+        var keyLookup = new Dictionary<string, string?>();
+        var flattened = new Dictionary<string, string?>();
         var sb = new StringBuilder(64);
 
         Flatten(node, flattened, keyLookup, sb);
 
-        return flattened.ToDictionary();
+        return flattened;
     }
 
     /// <summary>
@@ -60,8 +60,8 @@ public static partial class JsonExtensions
     /// </remarks>
     private static void Flatten(
         this JsonNode? node,
-        List<KeyValuePair<string, string?>> flattened,
-        Dictionary<string, int> keyLookup,
+        Dictionary<string, string?> flattened,
+        Dictionary<string, string?> keyLookup,
         StringBuilder sb)
     {
         switch (node)
@@ -107,16 +107,16 @@ public static partial class JsonExtensions
             default:
             {
                 var key = sb.ToString();
-                var kvp = new KeyValuePair<string, string?>(key, node?.ToString());
 
                 if (keyLookup.TryGetValue(key, out var existingIndex))
                 {
-                    flattened[existingIndex] = kvp;
+                    if (existingIndex is not null)
+                        flattened[existingIndex] = node?.ToString();
                 }
                 else
                 {
-                    keyLookup[key] = flattened.Count;
-                    flattened.Add(kvp);
+                    flattened.Add(key, node?.ToString());
+                    keyLookup.Add(key, flattened.Count.ToString());
                 }
 
                 break;

--- a/DecSm.Extensions.Json/JsonExtensions.Flatten.cs
+++ b/DecSm.Extensions.Json/JsonExtensions.Flatten.cs
@@ -5,7 +5,7 @@
 ///     Path conventions:
 ///     - Object properties are separated by colons (e.g., "user:address:city").
 ///     - Arrays are addressed with bracketed indices (e.g., "users:[0]:name") in flattened/unflattened keys.
-///     - For in-place replacement via <see cref="ReplaceValues" />, array steps use bare numeric segments (e.g., "users:0:name").
+///     - For in-place replacement via <see cref="ReplaceValues(JsonObject,Dictionary{string,string}, string)" />, array steps use bare numeric segments (e.g., "users:0:name").
 ///     These helpers are allocation‑conscious and designed for clarity when manipulating JSON in config and ETL scenarios.
 /// </summary>
 public static partial class JsonExtensions
@@ -16,9 +16,10 @@ public static partial class JsonExtensions
     ///     use bracket notation with zero-based indices.
     /// </summary>
     /// <param name="node">The JSON node to flatten. Can be a JsonObject, JsonArray, or primitive value.</param>
+    /// <param name="separator">The separator character to use between object property segments. Default is ':'.</param>
     /// <returns>
     ///     A dictionary mapping each path to its string representation.
-    ///     - Keys use colons for object properties and [index] notation for arrays.
+    ///     - Keys use <see ref="separator"/> for object properties and [index] notation for arrays.
     ///     - Values are the string representation of the JSON values (null for JSON null values).
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="node" /> is null.</exception>
@@ -29,7 +30,7 @@ public static partial class JsonExtensions
     /// // Result: [("user:name", "John"), ("user:tags:[0]", "admin"), ("user:tags:[1]", "user")]
     /// ]]></code>
     /// </example>
-    public static IDictionary<string, string?> Flatten(JsonNode node)
+    public static IDictionary<string, string?> Flatten(JsonNode node, string separator = ":")
     {
         ArgumentNullException.ThrowIfNull(node);
 
@@ -37,7 +38,7 @@ public static partial class JsonExtensions
         var flattened = new Dictionary<string, string?>();
         var sb = new StringBuilder(64);
 
-        Flatten(node, flattened, keyLookup, sb);
+        Flatten(node, flattened, keyLookup, sb, separator);
 
         return flattened;
     }
@@ -50,6 +51,7 @@ public static partial class JsonExtensions
     /// <param name="flattened">The list to add flattened key-value pairs to.</param>
     /// <param name="keyLookup">Dictionary for O(1) key lookups to avoid duplicates.</param>
     /// <param name="sb">A reusable StringBuilder holding the current path being built.</param>
+    /// <param name="separator">The separator character to use between object property segments.</param>
     /// <remarks>
     ///     The method handles three cases:
     ///     - JsonArray: Iterates through elements with [index] notation
@@ -62,14 +64,16 @@ public static partial class JsonExtensions
         this JsonNode? node,
         Dictionary<string, string?> flattened,
         Dictionary<string, string?> keyLookup,
-        StringBuilder sb)
+        StringBuilder sb,
+        string separator)
     {
         switch (node)
         {
             case JsonArray array:
             {
                 var baseLen = sb.Length;
-                sb.Append(":[");
+                sb.Append(separator);
+                sb.Append('[');
                 var indexStart = sb.Length;
 
                 for (var i = 0; i < array.Count; i++)
@@ -77,7 +81,7 @@ public static partial class JsonExtensions
                     sb.Length = indexStart;
                     sb.Append(i);
                     sb.Append(']');
-                    Flatten(array[i], flattened, keyLookup, sb);
+                    Flatten(array[i], flattened, keyLookup, sb, separator);
                 }
 
                 sb.Length = baseLen;
@@ -89,7 +93,7 @@ public static partial class JsonExtensions
                 var baseLen = sb.Length;
 
                 if (baseLen > 0)
-                    sb.Append(':');
+                    sb.Append(separator);
 
                 var keyStart = sb.Length;
 
@@ -97,7 +101,7 @@ public static partial class JsonExtensions
                 {
                     sb.Length = keyStart;
                     sb.Append(pair.Key);
-                    Flatten(pair.Value, flattened, keyLookup, sb);
+                    Flatten(pair.Value, flattened, keyLookup, sb, separator);
                 }
 
                 sb.Length = baseLen;

--- a/DecSm.Extensions.Json/JsonExtensions.ReplaceValue.cs
+++ b/DecSm.Extensions.Json/JsonExtensions.ReplaceValue.cs
@@ -7,20 +7,21 @@ public static partial class JsonExtensions
     /// </summary>
     /// <param name="root">The source JSON object to read from.</param>
     /// <param name="path">
-    ///     The property path to replace. Use colon-separated segments for nested objects
+    ///     The property path to replace. Use <see ref="separator"/>-separated segments for nested objects
     ///     (e.g., "user:address:city"). Array indices are not supported by this method.
-    ///     If the path contains no colons, it is treated as a simple, root-level property name.
+    ///     If the path contains no <see ref="separator"/>s, it is treated as a simple, root-level property name.
     /// </param>
     /// <param name="value">The new value to assign at the specified path. Use <c>null</c> for JSON null.</param>
+    /// <param name="separator">The separator used to split path segments. Defaults to colon (":").</param>
     /// <returns>
     ///     A new <see cref="JsonObject" /> with the requested change applied, leaving the original object unchanged.
-    ///     For simple paths (no colons), the property is only replaced if it already exists; missing properties are not added.
-    ///     For colon-separated paths, only existing intermediate objects are traversed; missing segments are not created.
+    ///     For simple paths (no <see ref="separator"/>s), the property is only replaced if it already exists; missing properties are not added.
+    ///     For <see ref="separator"/>-separated paths, only existing intermediate objects are traversed; missing segments are not created.
     ///     If a segment is missing, the value is set on the last navigated object (potentially the root) under the final segment name.
     /// </returns>
     /// <remarks>
     ///     This method is intentionally conservative about creating structure. If you need conditional creation and
-    ///     support for arrays, see <see cref="ReplaceValues" />.
+    ///     support for arrays, see <see cref="M:DecSm.Extensions.Json.JsonExtensions.ReplaceValues(JsonObject,Dictionary{string,string},string)" />.
     ///     Setting <paramref name="value" /> to null results in a JSON null at the target path.
     ///     If <paramref name="root" /> is null, a <see cref="NullReferenceException" /> will be thrown by extension method invocation semantics.
     /// </remarks>
@@ -34,7 +35,7 @@ public static partial class JsonExtensions
     /// // Unchanged structure; returns a clone with no new property added.
     /// ]]></code>
     /// </example>
-    public static JsonObject ReplaceValue(this JsonObject root, string path, string? value)
+    public static JsonObject ReplaceValue(this JsonObject root, string path, string? value, string separator = ":")
     {
         ArgumentNullException.ThrowIfNull(path);
 
@@ -42,8 +43,8 @@ public static partial class JsonExtensions
         if (path.Length is 0)
             return root;
 
-        // If the path doesn't contain colons, handle as a simple key replacement
-        if (!path.Contains(':'))
+        // If the path doesn't contain separator, handle as a simple key replacement
+        if (!path.Contains(separator))
         {
             if (root.ContainsKey(path))
                 root[path] = JsonValue.Create(value);
@@ -52,7 +53,7 @@ public static partial class JsonExtensions
         }
 
         // Handle nested path replacement
-        var pathSegments = path.Split(':');
+        var pathSegments = path.Split(separator);
         var current = root;
 
         // Navigate to the parent of the target key

--- a/DecSm.Extensions.Json/JsonExtensions.ReplaceValue.cs
+++ b/DecSm.Extensions.Json/JsonExtensions.ReplaceValue.cs
@@ -39,40 +39,21 @@ public static partial class JsonExtensions
         ArgumentNullException.ThrowIfNull(path);
 
         // Ignore empty paths for consistency with batch Replace
-        if (path.Length == 0)
-        {
-            var unchanged = new JsonObject();
-
-            foreach (var kvp in root)
-                unchanged[kvp.Key] = kvp.Value?.DeepClone();
-
-            return unchanged;
-        }
+        if (path.Length is 0)
+            return root;
 
         // If the path doesn't contain colons, handle as a simple key replacement
         if (!path.Contains(':'))
         {
-            var simpleResult = new JsonObject();
-
-            // Copy all existing key-value pairs
-            foreach (var kvp in root)
-                simpleResult[kvp.Key] = kvp.Value?.DeepClone();
-
-            // Replace the specified key with the new value
-            // Don't add it if it doesn't already exist
             if (root.ContainsKey(path))
-                simpleResult[path] = JsonValue.Create(value);
+                root[path] = JsonValue.Create(value);
 
-            return simpleResult;
+            return root;
         }
 
         // Handle nested path replacement
-        var complexResult = root
-            .DeepClone()
-            .AsObject();
-
         var pathSegments = path.Split(':');
-        var current = complexResult;
+        var current = root;
 
         // Navigate to the parent of the target key
         for (var i = 0; i < pathSegments.Length - 1; i++)
@@ -87,6 +68,6 @@ public static partial class JsonExtensions
         var finalKey = pathSegments[^1];
         current[finalKey] = JsonValue.Create(value);
 
-        return complexResult;
+        return root;
     }
 }

--- a/DecSm.Extensions.Json/JsonExtensions.Unflatten.cs
+++ b/DecSm.Extensions.Json/JsonExtensions.Unflatten.cs
@@ -4,14 +4,15 @@ public static partial class JsonExtensions
 {
     /// <summary>
     ///     Reconstructs a hierarchical JSON object from flattened key-value pairs.
-    ///     This method reverses the flattening process by parsing colon-separated paths
+    ///     This method reverses the flattening process by parsing <see ref="separator"/>-separated paths
     ///     and bracket notation to rebuild the original nested structure.
     /// </summary>
     /// <param name="flattened">
     ///     An enumerable of tuples containing flattened key-value pairs where:
-    ///     - Key: Path string using colon separation for objects and [index] notation for arrays
+    ///     - Key: Path string using <see ref="separator"/> separation for objects and [index] notation for arrays
     ///     - Value: String representation of the value (null for JSON null values)
     /// </param>
+    /// <param name="separator">The separator character used between object property segments (default is ':').</param>
     /// <returns>
     ///     A JsonObject representing the reconstructed hierarchical structure.
     ///     Arrays and nested objects are created as needed based on the path notation.
@@ -38,11 +39,11 @@ public static partial class JsonExtensions
     ///     - Overwriting existing values when the same path is encountered multiple times
     ///     - Note: Array indices are applied in append order; sparse/non-sequential indices are not padded.
     ///     Path parsing rules:
-    ///     - Colons (':') separate object property names
+    ///     - <see ref="separator"/> separate object property names
     ///     - Square brackets with numbers ([0], [1], etc.) indicate array indices
     ///     - Mixed object/array paths are supported (e.g., "users:[0]:name")
     /// </remarks>
-    public static JsonObject Unflatten(IDictionary<string, string?> flattened)
+    public static JsonObject Unflatten(IDictionary<string, string?> flattened, string separator = ":")
     {
         ArgumentNullException.ThrowIfNull(flattened);
 
@@ -50,8 +51,8 @@ public static partial class JsonExtensions
 
         foreach (var (key, value) in flattened)
         {
-            // Split the flattened key into path segments using colon as delimiter
-            var path = key.Split(':');
+            // Split the flattened key into path segments using the provided separator as delimiter
+            var path = key.Split(separator);
 
             // Track the current object context during path traversal
             var currentObject = obj;

--- a/DecSm.Extensions.Json/JsonExtensions.Unflatten.cs
+++ b/DecSm.Extensions.Json/JsonExtensions.Unflatten.cs
@@ -42,7 +42,7 @@ public static partial class JsonExtensions
     ///     - Square brackets with numbers ([0], [1], etc.) indicate array indices
     ///     - Mixed object/array paths are supported (e.g., "users:[0]:name")
     /// </remarks>
-    public static JsonObject Unflatten(IReadOnlyDictionary<string, string?> flattened)
+    public static JsonObject Unflatten(IDictionary<string, string?> flattened)
     {
         ArgumentNullException.ThrowIfNull(flattened);
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ using DecSm.Extensions.Json;
 ```csharp
 var json = JsonNode.Parse("""{ "user": { "name": "John", "tags": ["admin", "user"] } }""")!;
 var flattened = JsonExtensions.Flatten(json);
-// flattened is an IReadOnlyDictionary<string, string?> like:
+// flattened is an IDictionary<string, string?> like:
 // [
 //   ("user:name", "John"),
 //   ("user:tags:[0]", "admin"),
@@ -57,7 +57,7 @@ var obj = JsonExtensions.Unflatten(flat);
 // {"user":{"name":"John","tags":["admin","user"]}}
 ```
 
-### Replace a single value (returns a new object)
+### Replace a single value in-place
 
 ```csharp
 var root = JsonNode.Parse("""{ "user": { "details": { "city": "NYC" } } }""")!.AsObject();

--- a/_atom/Build.cs
+++ b/_atom/Build.cs
@@ -72,7 +72,6 @@ internal partial class Build : DefaultBuildDefinition,
                         $"run --project {JsonExtensionsBenchmarkProjectName} --configuration Release")
                     {
                         WorkingDirectory = FileSystem.AtomRootDirectory,
-                        OutputLogLevel = LogLevel.Information,
                     },
                     cancellationToken);
 


### PR DESCRIPTION
- Introduced `separator` parameter to methods like `ReplaceValue`, `ReplaceValues`, `Flatten`, and `Unflatten`.
- Default separator remains colon (`:`), ensuring backward compatibility.
- Enhanced flexibility for nested JSON path handling by supporting configurable separators in all relevant methods.
- Updated internal logic to respect the `separator` parameter in traversals and manipulations.
- Adjusted method summaries and XML documentation accordingly.
- Simplified `ReplaceValue` logic by modifying objects in place.
- Changed `Flatten` to use `IDictionary<string, string?>` for better mutability.
- Streamlined internal logic for `Flatten` to eliminate redundant operations.
- Updated `Unflatten` and benchmarks to align with new `Flatten` contract.
- Adjusted README to reflect updates to method behaviors.